### PR TITLE
Only refresh display when CPU temperature changes

### DIFF
--- a/examples/cputemp.py
+++ b/examples/cputemp.py
@@ -73,7 +73,7 @@ while True:
             show_number(temperature, 255, 255, 0)
         else:
             show_number(temperature, 255, 0, 0)
-        lastemperature = temperature
+        lastTemperature = temperature
     time.sleep(2)
 
 ledmatrix.clear()


### PR DESCRIPTION
The existing cputemp example refreshed the display every 2 seconds, even though the intent was only to refresh when the temperature changed.

This  one character change fixes a typo in the previous temperature variable assignment (use 'lastTemperature' rather than 'lastemperature'). The external behaviour remains the same, although it's slightly more efficient, and the display may appear to "flash" less frequently.